### PR TITLE
fix: repair to generage jacoco xml report (#7)

### DIFF
--- a/.github/workflows/CI_gradle.yml
+++ b/.github/workflows/CI_gradle.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           files: '**/build/test-results/test/TEST-*.xml'
 
-
       - name: (Test) Test Failure Occurred Documentation.
         uses: mikepenz/action-junit-report@v3
         if: always()
@@ -48,16 +47,11 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           token: ${{ github.token }}
 
-      - name: (Test) Run Test Coverage Measurement
-        run: |
-          chmod +x gradlew
-          ./gradlew testCoverage
-
-      - name: (Test) Test Coverage Report to PR
+      - name: (Test) Jacoco Coverage Report to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:
-          paths: ${{ github.workspace }}/build/reports/jacoco/testCoverage/testCoverage.xml
+          paths: ${{ github.workspace }}/build/JacocoReportDir/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60
@@ -65,3 +59,9 @@ jobs:
           update-comment: true
           pass-emoji: ':o:'
           fail-emoji: ':x:'
+
+      - name: (Test) Coveralls Coverage Badge
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ github.token }}
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img src="https://github.com/TeamCommerce/backend-server/assets/112257466/f183428d-cc93-440d-9b01-24c0bc667765" width=99%>
 
+[![Coverage Status](https://coveralls.io/repos/github/TeamCommerce/backend-server/badge.svg?branch=master)](https://coveralls.io/github/TeamCommerce/backend-server?branch=master)
+
 ---
 
 ## 📔&nbsp;&nbsp;Project Overview

--- a/build.gradle
+++ b/build.gradle
@@ -1,90 +1,62 @@
 plugins {
-	id 'java'
-	id 'jacoco'
-	id 'org.springframework.boot' version '3.1.2'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'jacoco'
+    id 'org.springframework.boot' version '3.1.2'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.commerce'
 version = '0.0.1-SNAPSHOT'
 
 jacoco {
-	toolVersion = "0.8.10"
+    toolVersion = "0.8.10"
+    reportsDirectory = layout.buildDirectory.dir('JacocoReportDir')
 }
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok' // 테스트 의존성 추가
-	testAnnotationProcessor 'org.projectlombok:lombok' // 테스트 의존성 추가
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok' // 테스트 의존성 추가
+    testAnnotationProcessor 'org.projectlombok:lombok' // 테스트 의존성 추가
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+test {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
-tasks.withType(Test) {
-	jacoco.includeNoLocationClasses = true
-	jacoco.excludes = ['jdk.internal.*']
-}
-
-tasks.create(name: "testCoverage", type: JacocoReport, dependsOn: "test") {
-
-	group = "Reporting"
-	description = "Generate Jacoco coverage reports for the test build."
-
-	reports {
-		html.required.set(true)
-		xml.required.set(true)
-	}
-
-	def excludes = [
-			'**/*Test*.*',
-			'**/actions/*.*',
-			'**/core/*.*',
-			'**/markers/*.*',
-			'**/services/**/*.*',
-			'**/toolwindow/*.*',
-			'**/utils/*.*'
-	]
-
-	def javaClasses = fileTree(dir: "${buildDir}/classes/java/main", excludes: excludes)
-	def kotlinClasses = fileTree(dir: "${buildDir}/classes/kotlin/main", excludes: excludes)
-	classDirectories.from = files([javaClasses, kotlinClasses])
-
-	sourceDirectories.from = files([
-			"$project.projectDir/src/main/java",
-			"$project.projectDir/src/main/kotlin",
-			"$buildDir/generated/source/kapt/test"
-	])
-
-	executionData.from = files("${project.buildDir}/jacoco/test.exec")
+jacocoTestReport {
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
 }
 
 task copyGitSubmodule(type: Copy) {
-	from './backend-config'
-	include '*.yml'
-	into './src/main/resources'
+    from './backend-config'
+    include '*.yml'
+    into './src/main/resources'
 }


### PR DESCRIPTION
## Issue ticket link and number
- #1 

## Describe changes
- jacoco Test Report가 `.xml` 확장자로 생성되지 않는 이슈를 수정
- coverall 라이브러리를 활용해, Master Branch의 README.md에 전체 커버리지 뱃지 생성