### PR TITLE
chore: Fixing the issue where the CI pipeline doesn't run for a specific PR

### DIFF
--- a/.github/workflows/CICD_gradle.yml
+++ b/.github/workflows/CICD_gradle.yml
@@ -2,9 +2,6 @@ name: CI-CD
 
 on:
   pull_request:
-    branches:
-      - 'master'
-      - 'develop'
   push:
     branches:
       - 'develop'


### PR DESCRIPTION
## Issue ticket link and number
- #42 

## Describe changes
- CI 파이프라인의 PR 브랜치 조건을 삭제하고, PR은 분기 브랜치 관계 없이, 모든 브랜치에서 동작하도록 설계합니다.
- 
