### PR TITLE
fix: To Tracking Build Status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <br>
 
-<a href="https://github.com/TeamCommerce/backend-server/actions/"><img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/TeamCommerce/backend-server/CI_gradle.yml?style=for-the-badge&logo=gradle"></a>
+<a href="https://github.com/TeamCommerce/backend-server/actions?query=branch%3Amaster"><img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/TeamCommerce/backend-server/CICD_gradle.yml?style=for-the-badge&logo=gradle"></a>
 <a href="https://coveralls.io/github/TeamCommerce/backend-server"/><img alt="Coveralls Coverage" src="https://img.shields.io/coverallsCoverage/github/TeamCommerce/backend-server?style=for-the-badge&logo=JUnit5&logoColor=white"></a>
 <a href=""/><img alt="Last Commit" src="https://img.shields.io/github/last-commit/TeamCommerce/backend-server/master?style=for-the-badge&label=LAST%20BUILD&logo=Github"></a>
 </div>


### PR DESCRIPTION
## Issue ticket link and number
- #73 
- #72 


## Describe changes
<img width="465" alt="스크린샷 2023-09-17 오전 9 26 57" src="https://github.com/TeamCommerce/backend-server/assets/112257466/beb8e567-b948-4ed8-84de-dc9db80f863c">

- Build가 Passing으로 표기되지 않는 오류를 Hotfix 합니다.
- CI-CD 파이프라인의 이름 변경 이후, yml파일을 추적하지 못해 생긴 이슈입니다.
