### PR TITLE
refactor: 예외 응답스펙 및 에러코드 스펙 수정

### DIFF
--- a/src/main/java/com/commerce/backendserver/auth/exception/AuthError.java
+++ b/src/main/java/com/commerce/backendserver/auth/exception/AuthError.java
@@ -11,12 +11,13 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @Getter
 @RequiredArgsConstructor
 public enum AuthError implements ErrorCode {
-    TOKEN_EXPIRED("만료된 토큰입니다.", BAD_REQUEST),
-    TOKEN_INVALID("유효하지 않은 토큰입니다.", BAD_REQUEST),
-    NOT_EXIST_OAUTH_TYPE("지원하지 않는 소셜 로그인 타입 입니다.", BAD_REQUEST),
-    NEED_LOGIN("로그인이 필요합니다.", UNAUTHORIZED),
+    TOKEN_EXPIRED("만료된 토큰입니다.", BAD_REQUEST, "A_001"),
+    TOKEN_INVALID("유효하지 않은 토큰입니다.", BAD_REQUEST, "A_002"),
+    NOT_EXIST_OAUTH_TYPE("지원하지 않는 소셜 로그인 타입 입니다.", BAD_REQUEST, "A_003"),
+    NEED_LOGIN("로그인이 필요합니다.", UNAUTHORIZED, "A_004"),
     ;
 
     private final String message;
     private final HttpStatus status;
+    private final String code;
 }

--- a/src/main/java/com/commerce/backendserver/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/commerce/backendserver/global/exception/ApiExceptionHandler.java
@@ -19,8 +19,7 @@ public class ApiExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        log.error("", ex);
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, Optional.ofNullable(ex.getFieldError()));
+        return ErrorResponse.of(Optional.ofNullable(ex.getFieldError()));
     }
 
     @ExceptionHandler(CommerceException.class)

--- a/src/main/java/com/commerce/backendserver/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/commerce/backendserver/global/exception/error/ErrorCode.java
@@ -7,4 +7,6 @@ public interface ErrorCode {
     String getMessage();
 
     HttpStatus getStatus();
+
+    String getCode();
 }

--- a/src/main/java/com/commerce/backendserver/global/exception/error/ErrorResponse.java
+++ b/src/main/java/com/commerce/backendserver/global/exception/error/ErrorResponse.java
@@ -1,5 +1,7 @@
 package com.commerce.backendserver.global.exception.error;
 
+import static com.commerce.backendserver.global.exception.error.GlobalError.*;
+
 import lombok.Getter;
 import org.springframework.validation.FieldError;
 
@@ -27,6 +29,6 @@ public class ErrorResponse {
 
     public static ErrorResponse of(Optional<FieldError> fieldError) {
         return fieldError.map(error -> new ErrorResponse(error.getCode(), error.getDefaultMessage()))
-            .orElseGet(() -> new ErrorResponse("G_100", "Invalid Param"));
+            .orElseGet(() -> ErrorResponse.of(INVALID_REQUEST_PARAM));
     }
 }

--- a/src/main/java/com/commerce/backendserver/global/exception/error/ErrorResponse.java
+++ b/src/main/java/com/commerce/backendserver/global/exception/error/ErrorResponse.java
@@ -1,7 +1,6 @@
 package com.commerce.backendserver.global.exception.error;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 
 import java.time.LocalDateTime;
@@ -12,22 +11,22 @@ public class ErrorResponse {
 
     private final String timeStamp;
 
-    private final int errorCode;
+    private final String errorCode;
 
     private final String errorMessage;
 
-    private ErrorResponse(int errorCode, String errorMessage) {
+    private ErrorResponse(String errorCode, String errorMessage) {
         this.timeStamp = LocalDateTime.now().toString();
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
     }
 
     public static ErrorResponse of(ErrorCode errorCode) {
-        return new ErrorResponse(errorCode.getStatus().value(), errorCode.getMessage());
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
     }
 
-    public static ErrorResponse of(HttpStatus httpStatus, Optional<FieldError> fieldError) {
-        return fieldError.map(error -> new ErrorResponse(httpStatus.value(), error.getDefaultMessage()))
-            .orElseGet(() -> new ErrorResponse(httpStatus.value(), "Invalid Param"));
+    public static ErrorResponse of(Optional<FieldError> fieldError) {
+        return fieldError.map(error -> new ErrorResponse(error.getCode(), error.getDefaultMessage()))
+            .orElseGet(() -> new ErrorResponse("G_100", "Invalid Param"));
     }
 }

--- a/src/main/java/com/commerce/backendserver/global/exception/error/GlobalError.java
+++ b/src/main/java/com/commerce/backendserver/global/exception/error/GlobalError.java
@@ -9,9 +9,10 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Getter
 @RequiredArgsConstructor
 public enum GlobalError implements ErrorCode {
-    GLOBAL_NOT_FOUND("Not Found Error!", NOT_FOUND);
+
+    GLOBAL_NOT_FOUND("Not Found Error!", NOT_FOUND, "G_001");
 
     private final String message;
-
     private final HttpStatus status;
+    private final String code;
 }

--- a/src/main/java/com/commerce/backendserver/global/exception/error/GlobalError.java
+++ b/src/main/java/com/commerce/backendserver/global/exception/error/GlobalError.java
@@ -1,16 +1,18 @@
 package com.commerce.backendserver.global.exception.error;
 
+import static org.springframework.http.HttpStatus.*;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @RequiredArgsConstructor
 public enum GlobalError implements ErrorCode {
 
-    GLOBAL_NOT_FOUND("Not Found Error!", NOT_FOUND, "G_001");
+    GLOBAL_NOT_FOUND("Not Found Error!", NOT_FOUND, "G_001"),
+    INVALID_REQUEST_PARAM("올바르지 않은 요청 파라미터입니다", BAD_REQUEST, "G_002"),
+    ;
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/commerce/backendserver/image/exception/ImageError.java
+++ b/src/main/java/com/commerce/backendserver/image/exception/ImageError.java
@@ -10,11 +10,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ImageError implements ErrorCode {
-    INVALID_IMAGE_TYPE("이미지 업로드에 실패했습니다.(type)", INTERNAL_SERVER_ERROR),
-    EMPTY_FILE("빈 파일입니다.", BAD_REQUEST),
-    UPLOAD_FAIL("이미지 업로드에 실패했습니다.", INTERNAL_SERVER_ERROR),
+    INVALID_IMAGE_TYPE("이미지 업로드에 실패했습니다.(type)", INTERNAL_SERVER_ERROR, "I_001"),
+    EMPTY_FILE("빈 파일입니다.", BAD_REQUEST, "I_002"),
+    UPLOAD_FAIL("이미지 업로드에 실패했습니다.", INTERNAL_SERVER_ERROR, "I_003"),
     ;
 
     private final String message;
     private final HttpStatus status;
+    private final String code;
 }

--- a/src/main/java/com/commerce/backendserver/product/exception/ProductError.java
+++ b/src/main/java/com/commerce/backendserver/product/exception/ProductError.java
@@ -13,25 +13,26 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum ProductError implements ErrorCode {
 
     // [Domain] Product
-    INVALID_PRICE_ATTRIBUTE("상품 가격 정보가 올바르지 않습니다.", BAD_REQUEST),
-    INVALID_OPTIONS("상품 옵션 정보가 올바르지 않습니다.", BAD_REQUEST),
-    PRODUCT_NOT_FOUND("상품 정보를 찾을 수 없습니다.", NOT_FOUND),
-    INVALID_PRODUCT_MAIN_IMAGE("상품 메인 사진 정보를 찾을 수 없습니다.", NOT_FOUND),
+    INVALID_PRICE_ATTRIBUTE("상품 가격 정보가 올바르지 않습니다.", BAD_REQUEST, "P_001"),
+    INVALID_OPTIONS("상품 옵션 정보가 올바르지 않습니다.", BAD_REQUEST, "P_002"),
+    PRODUCT_NOT_FOUND("상품 정보를 찾을 수 없습니다.", NOT_FOUND, "P_003"),
+    INVALID_PRODUCT_MAIN_IMAGE("상품 메인 사진 정보를 찾을 수 없습니다.", NOT_FOUND, "P_004"),
 
     // [Domain] ProductCommonInfo
-    UNKNOWN_BRAND("존재하지 않는 브랜드입니다.", BAD_REQUEST),
-    INVALID_BRAND("브랜드 정보가 올바르지 않습니다.", BAD_REQUEST),
-    INVALID_PRODUCT_NAME("상품 이름이 올바르지 않습니다.", BAD_REQUEST),
-    INVALID_PRODUCT_CATEGORY("상품 분류가 올바르지 않습니다.", BAD_REQUEST),
-    INVALID_PRODUCT_DESCRIPTION("상품 설명 정보가 올바르지 않습니다.", BAD_REQUEST),
-    TOO_LONG_PRODUCT_DESCRIPTION("상품 설명 정보가 제약조건 이상의 길이입니다.", BAD_REQUEST),
+    UNKNOWN_BRAND("존재하지 않는 브랜드입니다.", BAD_REQUEST, "P_005"),
+    INVALID_BRAND("브랜드 정보가 올바르지 않습니다.", BAD_REQUEST, "P_006"),
+    INVALID_PRODUCT_NAME("상품 이름이 올바르지 않습니다.", BAD_REQUEST, "P_007"),
+    INVALID_PRODUCT_CATEGORY("상품 분류가 올바르지 않습니다.", BAD_REQUEST, "P_008"),
+    INVALID_PRODUCT_DESCRIPTION("상품 설명 정보가 올바르지 않습니다.", BAD_REQUEST, "P_009"),
+    TOO_LONG_PRODUCT_DESCRIPTION("상품 설명 정보가 제약조건 이상의 길이입니다.", BAD_REQUEST, "P_010"),
 
     // [Domain] ProductPriceAttribute
-    INVALID_PROMOTION("상품 프로모션 정보가 올바르지 않습니다.", BAD_REQUEST),
-    INVALID_ORIGIN_PRICE("상품 정가가 올바르지 않습니다.", BAD_REQUEST),
-    MINUS_APPLIED_PROMOTION_PRICE("상품 프로모션 할인 적용가는 음수일 수 없습니다.", BAD_REQUEST);
+    INVALID_PROMOTION("상품 프로모션 정보가 올바르지 않습니다.", BAD_REQUEST, "P_011"),
+    INVALID_ORIGIN_PRICE("상품 정가가 올바르지 않습니다.", BAD_REQUEST, "P_012"),
+    MINUS_APPLIED_PROMOTION_PRICE("상품 프로모션 할인 적용가는 음수일 수 없습니다.", BAD_REQUEST, "P_013");
 
 
     private final String message;
     private final HttpStatus status;
+    private final String code;
 }

--- a/src/main/java/com/commerce/backendserver/review/exception/ReviewError.java
+++ b/src/main/java/com/commerce/backendserver/review/exception/ReviewError.java
@@ -11,12 +11,13 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @RequiredArgsConstructor
 public enum ReviewError implements ErrorCode {
 
-    INVALID_LENGTH("최소 5자 이상으로 작성해주세요.", BAD_REQUEST),
-    NOT_EXIST_INFO_NAME("존재하지 않는 추가 정보 이름입니다.", BAD_REQUEST),
-    INVALID_INTEGER_INFO_VALUE("숫자 관련 추가 정보에는 숫자만 입력해주세요.", BAD_REQUEST),
-    INVALID_ADDITIONAL_INFO("잘못된 형식의 추가정보 입니다.", BAD_REQUEST)
+    INVALID_LENGTH("최소 5자 이상으로 작성해주세요.", BAD_REQUEST, "R_001"),
+    NOT_EXIST_INFO_NAME("존재하지 않는 추가 정보 이름입니다.", BAD_REQUEST, "R_002"),
+    INVALID_INTEGER_INFO_VALUE("숫자 관련 추가 정보에는 숫자만 입력해주세요.", BAD_REQUEST, "R_003"),
+    INVALID_ADDITIONAL_INFO("잘못된 형식의 추가정보 입니다.", BAD_REQUEST, "R_004")
     ;
 
     private final String message;
     private final HttpStatus status;
+    private final String code;
 }

--- a/src/test/java/com/commerce/backendserver/auth/application/filter/JwtFilterTest.java
+++ b/src/test/java/com/commerce/backendserver/auth/application/filter/JwtFilterTest.java
@@ -182,7 +182,7 @@ public class JwtFilterTest {
     ) throws Exception {
         actions.andExpectAll(
             statusMatcher,
-            jsonPath("$.errorCode").value(errorCode.getStatus().value()),
+            jsonPath("$.errorCode").value(errorCode.getCode()),
             jsonPath("$.errorMessage").value(errorCode.getMessage())
         );
     }

--- a/src/test/java/com/commerce/backendserver/common/base/IntegrationTestBase.java
+++ b/src/test/java/com/commerce/backendserver/common/base/IntegrationTestBase.java
@@ -16,8 +16,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.payload.PayloadDocumentation;
-import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import org.springframework.restdocs.snippet.Attributes;
 import org.springframework.test.context.jdbc.Sql;
@@ -58,12 +56,6 @@ public abstract class IntegrationTestBase {
                 .build();
     }
 
-    protected ResponseFieldsSnippet successResponseDocument() {
-        return PayloadDocumentation.responseFields(
-                fieldWithPath("success").description("성공 여부")
-        );
-    }
-
     protected Attributes.Attribute constraint(String value) {
         return new Attributes.Attribute("constraints", value);
     }
@@ -85,7 +77,7 @@ public abstract class IntegrationTestBase {
     ) {
         response.statusCode(status.value())
                 .body("timeStamp", notNullValue(String.class))
-                .body("errorCode", is(status.value()))
+                .body("errorCode", notNullValue())
                 .body("errorMessage", is(errorMessage));
     }
 

--- a/src/test/java/com/commerce/backendserver/common/controller/TestController.java
+++ b/src/test/java/com/commerce/backendserver/common/controller/TestController.java
@@ -38,9 +38,12 @@ public class TestController {
             public String getMessage() {
                 return "error";
             }
-
             public HttpStatus getStatus() {
                 return httpStatus;
+            }
+
+            public String getCode() {
+                return "errorCode";
             }
         });
     }

--- a/src/test/java/com/commerce/backendserver/global/exception/ApiExceptionHandlerTest.java
+++ b/src/test/java/com/commerce/backendserver/global/exception/ApiExceptionHandlerTest.java
@@ -74,7 +74,8 @@ class ApiExceptionHandlerTest {
 	) throws Exception {
 		actions.andExpectAll(
 			statusMather,
-			jsonPath("$.errorMessage").value(errorMessage)
+			jsonPath("$.errorMessage").value(errorMessage),
+			jsonPath("$.errorCode").isNotEmpty()
 		);
 	}
 }

--- a/src/test/java/com/commerce/backendserver/global/exception/error/ErrorResponseTest.java
+++ b/src/test/java/com/commerce/backendserver/global/exception/error/ErrorResponseTest.java
@@ -1,8 +1,8 @@
 package com.commerce.backendserver.global.exception.error;
 
+import static com.commerce.backendserver.global.exception.error.GlobalError.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.http.HttpStatus.*;
 
 import java.util.Optional;
 
@@ -20,13 +20,14 @@ class ErrorResponseTest {
 		@DisplayName("when fieldError is null")
 		void whenFieldErrorIsNull() {
 			//when
-			ErrorResponse result = ErrorResponse.of(BAD_REQUEST, Optional.empty());
+			ErrorResponse result = ErrorResponse.of(Optional.empty());
 
 			//then
+
 			assertAll(
-				() -> assertThat(result.getErrorCode()).isEqualTo(BAD_REQUEST.value()),
+				() -> assertThat(result.getErrorCode()).isEqualTo(INVALID_REQUEST_PARAM.getCode()),
 				() -> assertThat(result.getTimeStamp()).isNotBlank(),
-				() -> assertThat(result.getErrorMessage()).isEqualTo("Invalid Param")
+				() -> assertThat(result.getErrorMessage()).isEqualTo(INVALID_REQUEST_PARAM.getMessage())
 			);
 		}
 	}


### PR DESCRIPTION
## Issue ticket link and number
- #80 

## Describe changes
- 기존 `ErrorCode interface` 에 `String getCode()` 추가
- 기존 `ErrorResponse` 에 `int errorCode` -> `String errorCode` 로 변경 
- 도메인별 ErrorCode 에 추가된 스펙 적용
- 변경된 스펙에 따라 테스트 코드 수정
