### PR TITLE
feat: 리뷰 엔티티 스펙에 productOptionId 추가

### DIFF
--- a/src/main/java/com/commerce/backendserver/review/application/ReviewService.java
+++ b/src/main/java/com/commerce/backendserver/review/application/ReviewService.java
@@ -7,7 +7,9 @@ import com.commerce.backendserver.product.infra.persistence.ProductQueryReposito
 import com.commerce.backendserver.review.application.dto.request.CreateReviewRequest;
 import com.commerce.backendserver.review.domain.Review;
 import com.commerce.backendserver.review.infra.persistence.ReviewRepository;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,28 +22,29 @@ import static com.commerce.backendserver.global.exception.error.GlobalError.GLOB
 @Transactional
 public class ReviewService {
 
-    private static final String REVIEW = "review";
+	private static final String REVIEW = "review";
 
-    private final ReviewRepository reviewRepository;
-    private final ImageService imageService;
-    private final ProductQueryRepository productQueryRepository;
+	private final ReviewRepository reviewRepository;
+	private final ImageService imageService;
+	private final ProductQueryRepository productQueryRepository;
 
-    public Long createReview(CreateReviewRequest request, Long writerId) {
+	public Long createReview(CreateReviewRequest request, Long writerId) {
 
-        List<String> imageUrls = imageService.uploadImages(request.files(), REVIEW);
+		List<String> imageUrls = imageService.uploadImages(request.files(), REVIEW);
 
-        Product product = productQueryRepository.findById(request.productId())
-                .orElseThrow(() -> CommerceException.of(GLOBAL_NOT_FOUND));
+		Product product = productQueryRepository.findById(request.productId())
+			.orElseThrow(() -> CommerceException.of(GLOBAL_NOT_FOUND));
 
-        Review review = Review.createReview(
-                request.contents(),
-                request.score(),
-                request.additionalInfo(),
-                product,
-                writerId,
-                imageUrls
-        );
+		Review review = Review.createReview(
+			request.contents(),
+			request.score(),
+			request.additionalInfo(),
+			product,
+			request.productId(),
+			writerId,
+			imageUrls
+		);
 
-        return reviewRepository.save(review).getId();
-    }
+		return reviewRepository.save(review).getId();
+	}
 }

--- a/src/main/java/com/commerce/backendserver/review/application/ReviewService.java
+++ b/src/main/java/com/commerce/backendserver/review/application/ReviewService.java
@@ -6,7 +6,7 @@ import com.commerce.backendserver.product.domain.Product;
 import com.commerce.backendserver.product.infra.persistence.ProductQueryRepository;
 import com.commerce.backendserver.review.application.dto.request.CreateReviewRequest;
 import com.commerce.backendserver.review.domain.Review;
-import com.commerce.backendserver.review.infra.ReviewRepository;
+import com.commerce.backendserver.review.infra.persistence.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/commerce/backendserver/review/application/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/commerce/backendserver/review/application/dto/request/CreateReviewRequest.java
@@ -18,6 +18,8 @@ public record CreateReviewRequest(
 
 	Long productId,
 
+	Long productOptionId,
+
 	@ValidAdditionalInfo
 	Set<String> additionalInfo,
 

--- a/src/main/java/com/commerce/backendserver/review/domain/Review.java
+++ b/src/main/java/com/commerce/backendserver/review/domain/Review.java
@@ -48,6 +48,8 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     private Product product;
 
+    private Long productOptionId;
+
     private Long writerId;
 
     @OneToMany(
@@ -64,6 +66,7 @@ public class Review extends BaseEntity {
         final Integer score,
         final Set<String> stringInfoSet,
         final Product product,
+        final Long productOptionId,
         final Long writerId,
         final List<String> imageUrls
     ) {
@@ -71,6 +74,7 @@ public class Review extends BaseEntity {
         this.score = score;
         this.additionalInfoList = AdditionalInfoList.of(stringInfoSet, this);
         this.product = product;
+        this.productOptionId = productOptionId;
         this.writerId = writerId;
         applyImages(imageUrls);
     }
@@ -91,6 +95,7 @@ public class Review extends BaseEntity {
         final Integer score,
         final Set<String> stringInfoSet,
         final Product product,
+        final Long productOptionId,
         final Long writerId,
         final List<String> imageUrls
     ) {
@@ -99,6 +104,7 @@ public class Review extends BaseEntity {
             .score(score)
             .stringInfoSet(stringInfoSet)
             .product(product)
+            .productOptionId(productOptionId)
             .writerId(writerId)
             .imageUrls(imageUrls)
             .build();

--- a/src/main/java/com/commerce/backendserver/review/infra/persistence/ReviewQueryRepository.java
+++ b/src/main/java/com/commerce/backendserver/review/infra/persistence/ReviewQueryRepository.java
@@ -1,10 +1,10 @@
-package com.commerce.backendserver.review.infra;
+package com.commerce.backendserver.review.infra.persistence;
 
 import com.commerce.backendserver.review.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.commerce.backendserver.review.infra.persistence.ReviewQueryDslRepository;
+import com.commerce.backendserver.review.infra.persistence.query.ReviewQueryDslRepository;
 
 @Transactional(readOnly = true)
 public interface ReviewQueryRepository extends JpaRepository<Review, Long>, ReviewQueryDslRepository {

--- a/src/main/java/com/commerce/backendserver/review/infra/persistence/ReviewRepository.java
+++ b/src/main/java/com/commerce/backendserver/review/infra/persistence/ReviewRepository.java
@@ -1,4 +1,4 @@
-package com.commerce.backendserver.review.infra;
+package com.commerce.backendserver.review.infra.persistence;
 
 import com.commerce.backendserver.review.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/commerce/backendserver/review/infra/persistence/query/ReviewQueryDslRepository.java
+++ b/src/main/java/com/commerce/backendserver/review/infra/persistence/query/ReviewQueryDslRepository.java
@@ -1,4 +1,4 @@
-package com.commerce.backendserver.review.infra.persistence;
+package com.commerce.backendserver.review.infra.persistence.query;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/commerce/backendserver/review/infra/persistence/query/ReviewQueryDslRepositoryImpl.java
+++ b/src/main/java/com/commerce/backendserver/review/infra/persistence/query/ReviewQueryDslRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.commerce.backendserver.review.infra.persistence;
+package com.commerce.backendserver.review.infra.persistence.query;
 
 import static com.commerce.backendserver.review.domain.QReview.*;
 import static com.commerce.backendserver.review.domain.additionalinfo.QAdditionalInfo.*;

--- a/src/test/java/com/commerce/backendserver/common/fixture/ReviewFixture.java
+++ b/src/test/java/com/commerce/backendserver/common/fixture/ReviewFixture.java
@@ -28,12 +28,13 @@ public enum ReviewFixture {
 	private final Set<String> stringInfoSet;
 	private final List<String> imageUrls;
 
-	public Review toEntity(Product product, Long writerId) {
+	public Review toEntity(Product product, Long writerId, Long productOptionId) {
 		return Review.createReview(
 			contents,
 			score,
 			stringInfoSet,
 			product,
+			productOptionId,
 			writerId,
 			imageUrls
 		);
@@ -43,6 +44,7 @@ public enum ReviewFixture {
 		return new CreateReviewRequest(
 			score,
 			contents,
+			1L,
 			1L,
 			stringInfoSet,
 			FileMockingUtils.createMockMultipartFiles()

--- a/src/test/java/com/commerce/backendserver/image/domain/ReviewImageTest.java
+++ b/src/test/java/com/commerce/backendserver/image/domain/ReviewImageTest.java
@@ -18,7 +18,7 @@ class ReviewImageTest {
 	void ofTest() {
 		//given
 		Product product = ProductFixture.VALID_PRODUCT.toEntity(null);
-		Review review = ReviewFixture.A.toEntity(product, 1L);
+		Review review = ReviewFixture.A.toEntity(product, 1L, 1L);
 
 		final String url = "testUrl.jpg";
 

--- a/src/test/java/com/commerce/backendserver/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/commerce/backendserver/review/application/ReviewServiceTest.java
@@ -7,7 +7,7 @@ import com.commerce.backendserver.product.domain.Product;
 import com.commerce.backendserver.product.infra.persistence.ProductQueryRepository;
 import com.commerce.backendserver.review.application.dto.request.CreateReviewRequest;
 import com.commerce.backendserver.review.domain.Review;
-import com.commerce.backendserver.review.infra.ReviewRepository;
+import com.commerce.backendserver.review.infra.persistence.ReviewRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/commerce/backendserver/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/commerce/backendserver/review/application/ReviewServiceTest.java
@@ -87,7 +87,7 @@ class ReviewServiceTest extends MockTestBase {
     }
 
     private Review generateReviewHasId() {
-        Review review = A.toEntity(null, null);
+        Review review = A.toEntity(null, null, null);
         setField(review, "id", 1L);
 
         return review;

--- a/src/test/java/com/commerce/backendserver/review/domain/ReviewTest.java
+++ b/src/test/java/com/commerce/backendserver/review/domain/ReviewTest.java
@@ -5,6 +5,7 @@ import com.commerce.backendserver.image.domain.Image;
 import com.commerce.backendserver.product.domain.Product;
 import com.commerce.backendserver.review.domain.additionalinfo.AdditionalInfo;
 import com.commerce.backendserver.review.domain.additionalinfo.constants.InfoName;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,35 +28,37 @@ public class ReviewTest {
 
 		//given
 		private final Product product = Product.createProduct(
-				new ArrayList<>(),
-				new ArrayList<>(),
+			new ArrayList<>(),
+			new ArrayList<>(),
 			null,
 			null);
 		private final Long writerId = 1L;
+		private final Long productOptionId = 1L;
 
 		@Test
 		@DisplayName("[Success] ImageUrl이 Null이 아닐 때 성공")
-		void SuccessWhenPresentimageUrlsIsNotNull() {
+		void SuccessWhenPresentImageUrlsIsNotNull() {
 			//given
 			final ReviewFixture fixture = ReviewFixture.A;
 
 			//when
-			Review result = fixture.toEntity(product, writerId);
+			Review result = fixture.toEntity(product, writerId, productOptionId);
 
 			//then
 			assertAll(
-					() -> assertThat(result.getScore()).isEqualTo(fixture.getScore()),
-					() -> assertThat(result.getContents()).isEqualTo(fixture.getContents()),
-					() -> assertThat(result.getWriterId()).isEqualTo(writerId),
-					() -> assertThat(result.getProduct()).isEqualTo(product),
-					() -> {
-						List<String> actual = result.getImages().stream().map(Image::getUrl).toList();
-						assertThat(actual).hasSameSizeAs(fixture.getImageUrls());
-						assertThat(actual).containsAll(fixture.getImageUrls());
-					},
-					() -> {
-						List<AdditionalInfo> actual = result.getAdditionalInfoList();
-						List<AdditionalInfo> expected = generateExpectedAdditionalInfo(fixture.getStringInfoSet());
+				() -> assertThat(result.getScore()).isEqualTo(fixture.getScore()),
+				() -> assertThat(result.getContents()).isEqualTo(fixture.getContents()),
+				() -> assertThat(result.getWriterId()).isEqualTo(writerId),
+				() -> assertThat(result.getProduct()).isEqualTo(product),
+				() -> assertThat(result.getProductOptionId()).isEqualTo(productOptionId),
+				() -> {
+					List<String> actual = result.getImages().stream().map(Image::getUrl).toList();
+					assertThat(actual).hasSameSizeAs(fixture.getImageUrls());
+					assertThat(actual).containsAll(fixture.getImageUrls());
+				},
+				() -> {
+					List<AdditionalInfo> actual = result.getAdditionalInfoList();
+					List<AdditionalInfo> expected = generateExpectedAdditionalInfo(fixture.getStringInfoSet());
 
 					assertAdditionalInfoMatching(actual, expected);
 				}
@@ -67,12 +70,13 @@ public class ReviewTest {
 		void SuccessWhenImageUrlsNull() {
 			//when
 			Review result = Review.createReview(
-					null,
-					null,
-					null,
-					null,
-					null,
-					null
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null
 			);
 
 			//then

--- a/src/test/java/com/commerce/backendserver/review/domain/additionalinfo/AdditionalInfoListTest.java
+++ b/src/test/java/com/commerce/backendserver/review/domain/additionalinfo/AdditionalInfoListTest.java
@@ -29,6 +29,7 @@ class AdditionalInfoListTest {
 			null,
 			null,
 			null,
+			null,
 			null);
 
 		@Test

--- a/src/test/java/com/commerce/backendserver/review/domain/additionalinfo/AdditionalInfoTest.java
+++ b/src/test/java/com/commerce/backendserver/review/domain/additionalinfo/AdditionalInfoTest.java
@@ -33,7 +33,7 @@ public class AdditionalInfoTest {
 	@DisplayName("[registerReview method]")
 	void registerReview() {
 		//given
-		final Review review = A.toEntity(null, null);
+		final Review review = A.toEntity(null, null, null);
 		final AdditionalInfo additionalInfo = AdditionalInfo.of(InfoName.SIZE, "Large");
 
 		//when

--- a/src/test/java/com/commerce/backendserver/review/integration/ReviewAcceptanceFixture.java
+++ b/src/test/java/com/commerce/backendserver/review/integration/ReviewAcceptanceFixture.java
@@ -150,6 +150,7 @@ public abstract class ReviewAcceptanceFixture {
 		params.put("contents", fixture.getContents());
 		params.put("score", String.valueOf(fixture.getScore()));
 		params.put("productId", String.valueOf(1L));
+		params.put("productOptionId", String.valueOf(1L));
 		fixture.getStringInfoSet().forEach(info -> params.put("additionalInfo", info));
 
 		return params;

--- a/src/test/java/com/commerce/backendserver/review/integration/ReviewApiTest.java
+++ b/src/test/java/com/commerce/backendserver/review/integration/ReviewApiTest.java
@@ -151,6 +151,8 @@ class ReviewApiTest extends IntegrationTestBase {
 					.attributes(constraint("1~5 사이 정수")),
 				partWithName("productId")
 					.description("리뷰할 상품 ID"),
+				partWithName("productOptionId")
+					.description("리뷰할 상품의 옵션 ID"),
 				partWithName("additionalInfo")
 					.description("추가정보 이름/추가정보 값")
 					.attributes(constraint("지정된 이름만 사용가능"))


### PR DESCRIPTION
## Issue ticket link and number
- #83 

## Describe changes
- 리뷰 레포지토리 패키지 구조 변경 (커밋 b125eb7faf5e56a6adf8677965679bb5e3b9c2b8 참고)
- 리뷰 엔티티 스펙에 `Long productOptionId` 추가
- 리뷰 스펙 변경에 맞춰 서비스 로직, 테스트 코드 수정

## Note
- 레포지토리의 구조가 이전에 제가 말했던 방식이랑 조금 달라서 제가 리뷰쪽만 일단 수정했어요. **b125eb7faf5e56a6adf8677965679bb5e3b9c2b8** 커밋 보시고 확인해보시면 좋을거같아요.