### PR TITLE
feat: 소셜로그인 성공시 리다이렉트 처리로 변경

### DIFF
--- a/src/main/java/com/commerce/backendserver/auth/presentation/OAuthApiController.java
+++ b/src/main/java/com/commerce/backendserver/auth/presentation/OAuthApiController.java
@@ -29,8 +29,7 @@ public class OAuthApiController {
 	) {
 		URI authorizationUri = oauthService.getAuthorizationUri(provider);
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.setLocation(authorizationUri);
+		HttpHeaders headers = createRedirectHeaders(authorizationUri);
 
 		return new ResponseEntity<>(headers, FOUND);
 	}
@@ -40,8 +39,16 @@ public class OAuthApiController {
 		@PathVariable final String provider,
 		@ModelAttribute final OAuthLoginRequest request
 	) {
-		AuthTokenResponse response = oauthService.login(provider, request.code(), request.state());
+		URI redirectUri = oauthService.login(provider, request.code(), request.state());
 
-		return ResponseEntity.ok(response);
+		HttpHeaders headers = createRedirectHeaders(redirectUri);
+
+		return new ResponseEntity<>(headers, FOUND);
+	}
+
+	private HttpHeaders createRedirectHeaders(URI redirectUri) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(redirectUri);
+		return headers;
 	}
 }

--- a/src/test/java/com/commerce/backendserver/auth/integration/OAuthApiTest.java
+++ b/src/test/java/com/commerce/backendserver/auth/integration/OAuthApiTest.java
@@ -3,10 +3,9 @@ package com.commerce.backendserver.auth.integration;
 import static com.commerce.backendserver.auth.integration.fixture.OAuthRequestFixture.*;
 import static com.commerce.backendserver.common.utils.TokenUtils.*;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.*;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 import java.util.Set;
@@ -38,25 +37,6 @@ class OAuthApiTest extends IntegrationTestBase {
 
 	@MockBean
 	private RestTemplate restTemplate;
-
-	private RestDocumentationFilter redirectToOAuthAuthorizationDocuments() {
-		return document(
-			DEFAULT_PATH,
-			customOAuthApiSwagger(),
-			pathParameters(
-				parameterWithName("provider").description("소셜로그인 제공자")
-					.attributes(constraint("구글, 카카오만 지원함"))
-			)
-		);
-	}
-
-	private ResourceSnippetParametersBuilder customOAuthApiSwagger() {
-		return ResourceSnippetParameters.builder()
-			.tag("인증 API")
-			.summary("소셜 로그인 API - @eunchannam")
-			.links()
-			.description("provider 로 지정한 소셜로그인 제공자의 소셜로그인 페이지로 리다이랙트한다");
-	}
 
 	@Nested
 	@DisplayName("[redirectToOAuthAuthorization]")
@@ -109,23 +89,55 @@ class OAuthApiTest extends IntegrationTestBase {
 		@Test
 		@DisplayName("[Success] 구글 정보를 통해서 로그인한다")
 		void 구글() {
-			ValidatableResponse response = 구글_정보를_통해_로그인한다(spec);
+			ValidatableResponse response = 구글_정보를_통해_로그인한다(spec, Set.of(redirectToLoginSuccessUri()));
 
-			response
-				.statusCode(200)
-				.body("accessToken", notNullValue())
-				.body("refreshToken", notNullValue());
+			response.statusCode(HttpStatus.FOUND.value());
 		}
 
 		@Test
 		@DisplayName("[Success] 카카오 정보를 통해서 로그인한다")
 		void 카카오() {
-			ValidatableResponse response = 카카오_정보를_통해_로그인한다(spec);
+			ValidatableResponse response = 카카오_정보를_통해_로그인한다(spec, Set.of(redirectToLoginSuccessUri()));
 
-			response
-				.statusCode(200)
-				.body("accessToken", notNullValue())
-				.body("refreshToken", notNullValue());
+			response.statusCode(HttpStatus.FOUND.value());
 		}
+	}
+
+	private RestDocumentationFilter redirectToOAuthAuthorizationDocuments() {
+		return document(
+			DEFAULT_PATH,
+			customOAuthRedirectApiSwagger(),
+			pathParameters(
+				parameterWithName("provider").description("소셜로그인 제공자")
+					.attributes(constraint("구글, 카카오만 지원함"))
+			)
+		);
+	}
+
+	private RestDocumentationFilter redirectToLoginSuccessUri() {
+		return document(
+			DEFAULT_PATH,
+			customOAuthRedirectApiSwagger(),
+			responseHeaders(
+				headerWithName("Location")
+					.description("쿼리 파라미터로 access_token, refresh_token 정보를 담고있음")
+			)
+		);
+	}
+
+	private ResourceSnippetParametersBuilder customOAuthRedirectApiSwagger() {
+		return ResourceSnippetParameters.builder()
+			.tag("인증 API")
+			.summary("소셜 로그인 API - @eunchannam")
+			.links()
+			.description("provider 로 지정한 소셜로그인 제공자의 소셜로그인 페이지로 리다이랙트한다");
+	}
+
+	private ResourceSnippetParametersBuilder customOAuthLoginApiSwagger() {
+		return ResourceSnippetParameters.builder()
+			.tag("인증 API")
+			.summary("소셜 로그인 API(호출 X) - @eunchannam")
+			.links()
+			.description("내부적으로 처리되는 API 이며 직접 호출하지 않지만 해당 API 성공시 리다이랙트되는 정보에 Token 정보가 포함됨");
 	}
 }

--- a/src/test/java/com/commerce/backendserver/auth/integration/fixture/OAuthRequestFixture.java
+++ b/src/test/java/com/commerce/backendserver/auth/integration/fixture/OAuthRequestFixture.java
@@ -3,7 +3,6 @@ package com.commerce.backendserver.auth.integration.fixture;
 import static com.commerce.backendserver.common.fixture.CommonRequestFixture.*;
 import static lombok.AccessLevel.*;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
@@ -35,18 +34,24 @@ public final class OAuthRequestFixture {
 	}
 
 	public static ValidatableResponse 구글_정보를_통해_로그인한다(
-		final RequestSpecification spec
+		final RequestSpecification spec,
+		final Set<RestDocumentationFilter> documentations
 	) {
-		return getOAuthLoginRequest(spec, "google");
+		return getOAuthLoginRequest(spec, "google", documentations);
 	}
 
 	public static ValidatableResponse 카카오_정보를_통해_로그인한다(
-		final RequestSpecification spec
+		final RequestSpecification spec,
+		final Set<RestDocumentationFilter> documentations
 	) {
-		return getOAuthLoginRequest(spec, "kakao");
+		return getOAuthLoginRequest(spec, "kakao", documentations);
 	}
 
-	private static ValidatableResponse getOAuthLoginRequest(RequestSpecification spec, String provider) {
+	private static ValidatableResponse getOAuthLoginRequest(
+		final RequestSpecification spec,
+		final String provider,
+		final Set<RestDocumentationFilter> documentations
+	) {
 		String path = UriComponentsBuilder
 			.fromUriString(LOGIN_PATH)
 			.queryParam("code", "code")
@@ -55,7 +60,7 @@ public final class OAuthRequestFixture {
 
 		return getRequest(
 			RestAssured.given(spec).log().all(),
-			new HashSet<>(),
+			documentations,
 			path,
 			provider
 		);


### PR DESCRIPTION
## Issue ticket link and number
- #110 

## Describe changes
- 기존에 소셜로그인 성공시 body 를 통해 토큰정보를 응답하던 방식에서 **리다이렉트 + 쿼리파라미터** 방식으로 변경
- 내부호출되는 소셜로그인 API 를 명세
